### PR TITLE
Pick some less clashing colours and fix first-time-in exception

### DIFF
--- a/src/ui/Resources/Brushes.xaml
+++ b/src/ui/Resources/Brushes.xaml
@@ -42,7 +42,7 @@
         />
 
     <SolidColorBrush x:Key="ColumnHeadingBrush"
-        Color="{DynamicResource {x:Static vsshell:VsColors.ToolWindowTabTextKey}}"
+        Color="{DynamicResource {x:Static vsshell:VsColors.StartPageTextHeadingSelectedKey}}"
         />
 
     <SolidColorBrush x:Key="TitleBrush"
@@ -56,11 +56,11 @@
         />
 
     <SolidColorBrush x:Key="ItemNameBrush"
-        Color="{DynamicResource {x:Static vsshell:VsColors.ToolWindowTabSelectedTextKey}}"
+        Color="{DynamicResource {x:Static vsshell:VsColors.StartPageTextHeadingKey}}"
         />
 
     <SolidColorBrush x:Key="ItemDescriptionBrush"
-        Color="{DynamicResource {x:Static vsshell:VsColors.ToolWindowTabTextKey}}"
+        Color="{DynamicResource {x:Static vsshell:VsColors.StartPageTextBodyUnselectedKey}}"
         />
 
     <SolidColorBrush x:Key="ItemDateBrush"

--- a/src/ui/Services/RecentItemDataService.cs
+++ b/src/ui/Services/RecentItemDataService.cs
@@ -32,10 +32,10 @@ namespace StartPagePlus.UI.Services
             var items = new ObservableCollection<RecentItemViewModel>();
 
             using (var regKey = MainViewModel.RegistryRoot
-                .OpenSubKey(ROOT)
-                .OpenSubKey(METADATA)
-                .OpenSubKey(BASELINES)
-                .OpenSubKey(CODE_CONTAINERS)
+                ?.OpenSubKey(ROOT)
+                ?.OpenSubKey(METADATA)
+                ?.OpenSubKey(BASELINES)
+                ?.OpenSubKey(CODE_CONTAINERS)
                 )
             {
                 try
@@ -44,7 +44,13 @@ namespace StartPagePlus.UI.Services
                     {
                         return items;
                     }
-                    var offline = ((string)regKey.GetValue(OFFLINE)).Substring(1);
+
+                    var offline = ((string)regKey.GetValue(OFFLINE))?.Substring(1);
+                    if (offline == null)
+                    {
+                        return items;
+                    }
+
                     var results = JArray.Parse(offline).ToObject<List<RecentItem>>();
                     var today = DateTimeService.Today.Date;
 


### PR DESCRIPTION
The colours from the start menu palette are a bit less clashing and might change appropriately with the theme. Still not perfect, but at least visible on all the themes I tried!

Also handled a null reference when first running.